### PR TITLE
Resolver fixes

### DIFF
--- a/lib/resolveurl/plugins/estream.py
+++ b/lib/resolveurl/plugins/estream.py
@@ -2,7 +2,7 @@
     OVERALL CREDIT TO:
         t0mm0, Eldorado, VOINAGE, BSTRDMKR, tknorris, smokdpi, TheHighway
 
-    resolveurl XBMC Addon
+    resolveurl plugin
     Copyright (C) 2011 t0mm0
 
     This program is free software: you can redistribute it and/or modify
@@ -22,8 +22,8 @@ from __resolve_generic__ import ResolveGeneric
 
 class EstreamResolver(ResolveGeneric):
     name = "estream"
-    domains = ['estream.to', 'estream.nu']
-    pattern = '(?://|\.)(estream\.(?:to|nu))/(?:embed-)?([a-zA-Z0-9]+)'
+    domains = ['estream.to', 'estream.nu', 'estream.xyz']
+    pattern = '(?://|\.)(estream\.(?:to|nu|xyz))/(?:embed-)?([a-zA-Z0-9]+)'
     
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://estream.nu/{media_id}.html')
+        return self._default_get_url(host, media_id, template='https://estream.to/embed-{media_id}.html')

--- a/lib/resolveurl/plugins/streamango.py
+++ b/lib/resolveurl/plugins/streamango.py
@@ -21,8 +21,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class StreamangoResolver(ResolveUrl):
     name = "streamango"
-    domains = ['streamango.com', "streamcherry.com", "fruitstreams.com"]
-    pattern = '(?://|\.)((?:stream(?:ango|cherry)|fruitstreams)\.com)/(?:v/d|f|embed)/([0-9a-zA-Z]+)'
+    domains = ['streamango.com', 'streamcherry.com', 'fruitstreams.com', 'fruitadblock.net']
+    pattern = '(?://|\.)((?:stream(?:ango|cherry)|fruitstreams|fruitadblock)\.(?:com|net))/(?:v/d|f|embed)/([0-9a-zA-Z]+)'
     
     def __init__(self):
         self.net = common.Net()


### PR DESCRIPTION
Estream:
Additional domain
get_url changed to faster responding domain
`https://estream.to/embed-esxef3vlqq1o.html`

Streamango:
Additional domain