### PR TITLE
TheVideo.me -> Vev.io

### DIFF
--- a/lib/resolveurl/plugins/thevideo.py
+++ b/lib/resolveurl/plugins/thevideo.py
@@ -31,7 +31,7 @@ class TheVideoResolver(ResolveUrl):
     def __init__(self):
         self.net = common.Net()
         self.headers = {'User-Agent': common.SMR_USER_AGENT}
-        
+
 
     def get_media_url(self, host, media_id):
         try:
@@ -46,7 +46,7 @@ class TheVideoResolver(ResolveUrl):
         else:
             raise ResolverError('No Video Streams')
 
-            
+
     def __auth_ip(self, media_id):
         header = i18n('thevideo_auth_header')
         line1 = i18n('auth_required')
@@ -55,7 +55,7 @@ class TheVideoResolver(ResolveUrl):
         with common.kodi.CountdownDialog(header, line1, line2, line3) as cd:
             return cd.start(self.__check_auth, [media_id])
 
-            
+
     def __check_auth(self, media_id):
         common.logger.log('Checking Auth: %s' % (media_id))
         url = 'https://vev.io/api/pair/' + media_id
@@ -71,9 +71,9 @@ class TheVideoResolver(ResolveUrl):
             if e.code == 400:
                 pass # Continue. User hasn't paired yet.
             else:
-                raise ResolverError('Unexpected HTTP Response')                
+                raise ResolverError('Unexpected HTTP Response')
         return None
 
-            
+
     def get_url(self, host, media_id):
         return self._default_get_url(host, media_id, template='https://vev.io/embed/{media_id}')

--- a/lib/resolveurl/plugins/thevideo.py
+++ b/lib/resolveurl/plugins/thevideo.py
@@ -15,22 +15,23 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 '''
-import urllib
-import urllib2
 import json
+from urllib2 import HTTPError
 from lib import helpers
 from resolveurl import common
 from resolveurl.common import i18n
 from resolveurl.resolver import ResolveUrl, ResolverError
 
+
 class TheVideoResolver(ResolveUrl):
     name = "thevideo"
-    domains = ["thevideo.me", "tvad.me", "thevideo.cc", "thevideo.us", "thevideo.io", "thevideo.website"]
-    pattern = '(?://|\.)((?:thevideo\.(?:me|cc|us|io|website))|tvad\.me)/(?:embed-|download/)?([0-9a-zA-Z]+)'
+    domains = ["vev.io"]
+    pattern = '(?://|\.)((?:vev\.io))/(?:embed/)?(\w+)'
 
     def __init__(self):
         self.net = common.Net()
         self.headers = {'User-Agent': common.SMR_USER_AGENT}
+        
 
     def get_media_url(self, host, media_id):
         try:
@@ -40,38 +41,39 @@ class TheVideoResolver(ResolveUrl):
         except ResolverError:
             raise
 
-        if 'vt' in result:
-            vt = result['vt']
-            del result['vt']
-            return helpers.pick_source(result.items()) + '?' + urllib.urlencode({'vt': vt}) + helpers.append_headers(self.headers)
+        if result:
+            return helpers.pick_source(result)
         else:
-            raise ResolverError('Video Token Missing')
+            raise ResolverError('No Video Streams')
 
+            
     def __auth_ip(self, media_id):
         header = i18n('thevideo_auth_header')
         line1 = i18n('auth_required')
         line2 = i18n('visit_link')
-        line3 = i18n('click_pair') % ('https://tvad.me/pair')
+        line3 = i18n('click_pair') % ('https://vev.io/pair')
         with common.kodi.CountdownDialog(header, line1, line2, line3) as cd:
             return cd.start(self.__check_auth, [media_id])
 
+            
     def __check_auth(self, media_id):
         common.logger.log('Checking Auth: %s' % (media_id))
-        url = 'https://tvad.me/pair?file_code=%s&check' % (media_id)
-        try: js_result = json.loads(self.net.http_GET(url, headers=self.headers).content)
+        url = 'https://vev.io/api/pair/' + media_id
+        try:
+            r = self.net.http_GET(url, headers=self.headers)
+            if r._response.getcode() == 200:
+                js_result = json.loads(r.content, encoding='utf-8')
+                #common.logger.log('Auth Result: %s' % (js_result))
+                return js_result.get('qualities', {}).items()
         except ValueError:
             raise ResolverError('Unusable Authorization Response')
-        except urllib2.HTTPError as e:
-            if e.code == 401:
-                js_result = json.loads(str(e.read()))
+        except HTTPError as e:
+            if e.code == 400:
+                pass # Continue. User hasn't paired yet.
             else:
-                raise
+                raise ResolverError('Unexpected HTTP Response')                
+        return None
 
-        common.logger.log('Auth Result: %s' % (js_result))
-        if js_result.get('status'):
-            return js_result.get('response', {})
-        else:
-            return {}
-
+            
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://tvad.me/embed-{media_id}.html')
+        return self._default_get_url(host, media_id, template='https://vev.io/embed/{media_id}')

--- a/resources/language/English (US)/strings.po
+++ b/resources/language/English (US)/strings.po
@@ -49,8 +49,8 @@ msgid "Decryption Key"
 msgstr "Decryption Key"
 
 msgctxt "#33008"
-msgid "TheVideo.me Stream Authorization"
-msgstr "TheVideo.me Stream Authorization"
+msgid "Vev.io Stream Authorization"
+msgstr "Vev.io Stream Authorization"
 
 msgctxt "#33009"
 msgid "VidUP.me Stream Authorization"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -46,7 +46,7 @@ msgid "Decryption Key"
 msgstr ""
 
 msgctxt "#33008"
-msgid "TheVideo.me Stream Authorization"
+msgid "Vev.io Stream Authorization"
 msgstr ""
 
 msgctxt "#33009"


### PR DESCRIPTION
See the "Pair" section of https://vev.io/api

Any old thevideo links do redirect to vev.io, but none play. I think they started fresh after the new domain.  
So the old domains were removed from self.domains.