### PR TITLE
Verystream referer

### DIFF
--- a/lib/resolveurl/plugins/verystream.py
+++ b/lib/resolveurl/plugins/verystream.py
@@ -32,7 +32,7 @@ class VeryStreamResolver(ResolveUrl):
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
-        headers = {'User-Agent': common.FF_USER_AGENT}
+        headers = {'User-Agent': common.FF_USER_AGENT, 'Referer': 'https://verystream.com'}
         response = self.net.http_GET(web_url, headers=headers)
         html = response.content
 


### PR DESCRIPTION
Some videos are reported as deleted, until referer is provided.
I've tried several links so far and it was enough for the referrer to be verystream.com.
example: https://verystream.com/e/jULP4GWL3JU