### PR TITLE
Update xstreamcdn.py

### DIFF
--- a/lib/resolveurl/plugins/xstreamcdn.py
+++ b/lib/resolveurl/plugins/xstreamcdn.py
@@ -12,7 +12,7 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 class XStreamCDNResolver(ResolveUrl):
     name = 'XStreamCDN'
     domains = ['xstreamcdn.com']
-    pattern = '(?://|\.)(xstreamcdn\.com)/v/(\w+)' # Host and media-id pattern.
+    pattern = '(?://|\.)(xstreamcdn\.com)/v/([\w-]+)' # Host and media-id pattern.
  
     def __init__(self):
         self.net = Net()


### PR DESCRIPTION
Fixes #124 
Fix regex which fails when hyphens are used in the media-id