### PR TITLE
Update hmf.py

### DIFF
--- a/lib/resolveurl/hmf.py
+++ b/lib/resolveurl/hmf.py
@@ -256,6 +256,8 @@ class HostedMediaFile:
         try:
             msg = ''
             request = urllib2.Request(stream_url.split('|')[0], headers=headers)
+            # only do a HEAD request. gujal
+            request.get_method = lambda : 'HEAD'
             #  set urlopen timeout to 15 seconds
             http_code = urllib2.urlopen(request, timeout=15).getcode()
         except urllib2.URLError as e:


### PR DESCRIPTION
The test_stream method is doing a GET request which is causing large files to be downloaded in the background. Kodiplayer is also downloading the same file to display, so end up with two processes pulling the same large file twice causing wasted bandwidth.
Doing a HEAD request achieves the valid file check while not downloading the entire file.