### PR TITLE
New resolver dailynotion

### DIFF
--- a/lib/resolveurl/hmf.py
+++ b/lib/resolveurl/hmf.py
@@ -282,7 +282,7 @@ class HostedMediaFile:
         if int(http_code) >= 400:
             common.logger.log_warning('Stream UrlOpen Failed: Url: %s HTTP Code: %s Msg: %s' % (stream_url, http_code, msg))
 
-        return int(http_code) < 400
+        return int(http_code) < 400 or int(http_code) == 504
 
     def __nonzero__(self):
         if self._valid_url is None:

--- a/lib/resolveurl/plugins/dailynotion.py
+++ b/lib/resolveurl/plugins/dailynotion.py
@@ -1,0 +1,31 @@
+"""
+dailynotion ResolveUrl plugin
+Copyright (C) 2019 gujal
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from __resolve_generic__ import ResolveGeneric
+from lib import helpers
+
+class DailyNotionResolver(ResolveGeneric):
+    name = "dailynotion.me"
+    domains = ['dailynotion.me']
+    pattern = r'(?://|\.)(dailynotion\.me)/player/([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id):
+        return helpers.get_media_url(self.get_url(host, media_id), patterns=[r'''"src":"(?P<url>[^"]+)","label":"(?P<label>[^"]+)'''])
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='http://{host}/player/{media_id}/')


### PR DESCRIPTION
In addition to the new resolver, there is a minor change to hmf.py
Sometimes the HEAD request fails due to slow server response with ERROR 504.
In such cases, it is assumed that the link is available