### PR TITLE
[Streamz.cc] Move head request in the conditional

### DIFF
--- a/lib/resolveurl/plugins/streamz.py
+++ b/lib/resolveurl/plugins/streamz.py
@@ -37,9 +37,9 @@ class StreamzResolver(ResolveUrl):
         html += helpers.get_packed_data(html)
         sources = helpers.scrape_sources(html)
 
-        sources = [('mp4', self.net.http_HEAD(sources[0][1]).get_url())]
-
         if sources:
+
+            sources = [('mp4', self.net.http_HEAD(sources[0][1]).get_url())]
 
             headers.update({'Referer': web_url})
 


### PR DESCRIPTION
In order to properly result in ResolverError in case the scrape sources function does not end up in a result.