### PR TITLE
Fix settings file saving on kodi 19

### DIFF
--- a/lib/resolveurl/__init__.py
+++ b/lib/resolveurl/__init__.py
@@ -309,7 +309,7 @@ def _update_settings_xml():
     if old_xml != new_xml:
         common.logger.log_debug('Updating Settings XML')
         try:
-            with open(common.settings_file, 'w') as f:
+            with open(common.settings_file, 'w', encoding='utf-8') as f:
                 f.write(new_xml)
         except:
             raise


### PR DESCRIPTION
I got errors such as
```
Error Type: <class 'UnicodeEncodeError'>
Error Contents: 'charmap' codec can't encode characters in position 155-166: character maps to <undefined>
Traceback (most recent call last):
 File "C:\Users\xxx\Desktop\Kodi 19\Kodi\portable_data\addons\script.module.resolveurl\lib\default.py", line 20, in <module>
   from resolveurl.lib import kodi
 File "C:\Users\xxx\Desktop\Kodi 19\Kodi\portable_data\addons\script.module.resolveurl\lib\resolveurl\__init__.py", line 320, in <module>
   _update_settings_xml()
 File "C:\Users\xxx\Desktop\Kodi 19\Kodi\portable_data\addons\script.module.resolveurl\lib\resolveurl\__init__.py", line 313, in _update_settings_xml
   f.write(new_xml)
 File "C:\Users\xxx\Desktop\Kodi 19\Kodi\system\python\Lib\encodings\cp1252.py", line 19, in encode
   return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 155-166: character maps to <undefined>
```

when trying to save settings or perform actions such as 'reset function cache', while on kodi 19 and interface language other than english (ie settings labels not unicode).
This still works with older kodi versions.