### PR TITLE
Kodi 19 fix: xbmc.LOGNOTICE deprecated

### DIFF
--- a/lib/resolveurl/lib/log_utils.py
+++ b/lib/resolveurl/lib/log_utils.py
@@ -19,7 +19,14 @@ import json
 import xbmc
 import xbmcaddon
 import six
-from xbmc import LOGDEBUG, LOGERROR, LOGNOTICE, LOGWARNING
+
+LOGDEBUG = xbmc.LOGDEBUG
+LOGERROR = xbmc.LOGERROR
+LOGWARNING = xbmc.LOGWARNING
+try:
+    LOGNOTICE = xbmc.LOGNOTICE
+except AttributeError:
+    LOGNOTICE = xbmc.LOGINFO
 
 addonsmr = xbmcaddon.Addon('script.module.resolveurl')
 


### PR DESCRIPTION
See: https://forum.kodi.tv/showthread.php?tid=353818

note: I initially tried using if/else in combination with resolveurl.lib.kodi's `kodi_version()` function, instead of try/except, but I got 'circular import' attribute error.