### PR TITLE
fix UnicodeWarning

### DIFF
--- a/lib/resolveurl/__init__.py
+++ b/lib/resolveurl/__init__.py
@@ -310,7 +310,7 @@ def _update_settings_xml():
         old_xml = u''
 
     new_xml = six.ensure_text('\n'.join(new_xml))
-    if old_xml != new_xml:
+    if old_xml is new_xml:
         common.logger.log_debug('Updating Settings XML')
         try:
             if six.PY3:

--- a/lib/resolveurl/__init__.py
+++ b/lib/resolveurl/__init__.py
@@ -311,7 +311,7 @@ def _update_settings_xml():
     old_xml = six.ensure_text(old_xml)
 
     new_xml = six.ensure_text('\n'.join(new_xml))
-    if old_xml is new_xml:
+    if old_xml != new_xml:
         common.logger.log_debug('Updating Settings XML')
         try:
             if six.PY3:

--- a/lib/resolveurl/__init__.py
+++ b/lib/resolveurl/__init__.py
@@ -308,6 +308,7 @@ def _update_settings_xml():
                 old_xml = f.read()
     except:
         old_xml = u''
+    old_xml = six.ensure_text(old_xml)
 
     new_xml = six.ensure_text('\n'.join(new_xml))
     if old_xml is new_xml:


### PR DESCRIPTION
ERROR: xxx\script.module.resolveurl\lib\resolveurl\__init__.py:313: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal if old_xml != new_xml: