### PR TITLE
Encoding issue fix for py2

### DIFF
--- a/lib/resolveurl/lib/kodi.py
+++ b/lib/resolveurl/lib/kodi.py
@@ -126,7 +126,7 @@ else:
 
 def i18n(string_id):
     try:
-        return addon.getLocalizedString(strings.STRINGS[string_id])
+        return six.ensure_str(addon.getLocalizedString(strings.STRINGS[string_id]))
     except Exception as e:
         _log('Failed String Lookup: %s (%s)' % (string_id, e))
         return string_id


### PR DESCRIPTION
Latest version (5.1.16) is broken for systems running kodi up to 18.x with ui language other than English.
I think it was broken by 60f2659efec4d59fa52b1cc291222286d6706fe0
I suggest here to let `six` handle this.
Tested and working with kodi 18.x and 19 beta,  English and Greek ui.

Here's the log error:

```
2020-12-06 08:45:17.184 T:11552   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnicodeEncodeError'>
                                            Error Contents: 'ascii' codec can't encode characters in position 0-9: ordinal not in range(128)
                                            Traceback (most recent call last):
                                              File "C:\Users\host505\AppData\Roaming\Kodi\addons\script.module.resolveurl\lib\default.py", line 20, in <module>
                                                from resolveurl.lib import kodi
                                              File "C:\Users\host505\AppData\Roaming\Kodi\addons\script.module.resolveurl\lib\resolveurl\__init__.py", line 328, in <module>
                                                _update_settings_xml()
                                              File "C:\Users\host505\AppData\Roaming\Kodi\addons\script.module.resolveurl\lib\resolveurl\__init__.py", line 280, in _update_settings_xml
                                                new_xml += ['\t\t' + line for line in resolver.get_settings_xml()]
                                              File "C:\Users\host505\AppData\Roaming\Kodi\addons\script.module.resolveurl\lib\resolveurl\plugins\alldebrid.py", line 328, in get_settings_xml
                                                xml.append('<setting id="{0}_torrents" type="bool" label="{1}" default="true"/>'.format(cls.__name__, i18n('torrents')))
                                            UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-9: ordinal not in range(128)
                                            -->End of Python script error report<--
```