### PR TITLE
Allow dailymotion live streams

### DIFF
--- a/lib/resolveurl/plugins/dailymotion.py
+++ b/lib/resolveurl/plugins/dailymotion.py
@@ -39,9 +39,10 @@ class DailymotionResolver(ResolveUrl):
             raise ResolverError(js_result.get('error').get('title'))
 
         quals = js_result.get('qualities')
+
         if quals:
             mbtext = self.net.http_GET(quals.get('auto')[0].get('url'), headers=headers).content
-            sources = re.findall('NAME="(?P<label>[^"]+)",PROGRESSIVE-URI="(?P<url>[^#]+)', mbtext)
+            sources = re.findall('NAME="(?P<label>[^"]+)"(?:,PROGRESSIVE-URI="|\n)?(?P<url>[^#]+)', mbtext)
             return helpers.pick_source(helpers.sort_sources_list(sources)) + helpers.append_headers(headers)
         raise ResolverError('No playable video found.')
 

--- a/lib/resolveurl/plugins/dailymotion.py
+++ b/lib/resolveurl/plugins/dailymotion.py
@@ -25,8 +25,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class DailymotionResolver(ResolveUrl):
     name = 'dailymotion'
-    domains = ['dailymotion.com']
-    pattern = r'(?://|\.)(dailymotion\.com)/(?:video|embed|sequence|swf)(?:/video)?/([0-9a-zA-Z]+)'
+    domains = ['dailymotion.com', 'dai.ly']
+    pattern = r'(?://|\.)(dailymotion\.com|dai\.ly)(?:/(?:video|embed|sequence|swf)(?:/video)?)?/([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)


### PR DESCRIPTION
This commit will modify regex pattern on loaded m3u8 to allow live streams. Additional domain has been added in the second commit.
Test stream: https://www.dailymotion.com/video/xqjey2 (short: https://dai.ly/xqjey2)