### PR TITLE
HostedMediaFile add __bool__ for python 3

### DIFF
--- a/lib/resolveurl/hmf.py
+++ b/lib/resolveurl/hmf.py
@@ -294,6 +294,9 @@ class HostedMediaFile:
 
         return int(http_code) < 400 or int(http_code) == 504
 
+    def __bool__(self):
+        return self.__nonzero__()
+
     def __nonzero__(self):
         if self._valid_url is None:
             return self.valid_url()


### PR DESCRIPTION
In python 3,
resolveurl.HostedMediaFile(url=url) would always return true as the method to check bool is different than python 2.

https://stackoverflow.com/questions/8205558/defining-boolness-of-a-class-in-python