### PR TITLE
Add new domain for clipwatching

### DIFF
--- a/lib/resolveurl/plugins/clipwatching.py
+++ b/lib/resolveurl/plugins/clipwatching.py
@@ -23,8 +23,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class ClipWatchingResolver(ResolveUrl):
     name = "clipwatching"
-    domains = ['clipwatching.com']
-    pattern = r'(?://|\.)(clipwatching\.com)/(?:embed-)?(\w+)'
+    domains = ['clipwatching.com', 'highstream.tv']
+    pattern = r'(?://|\.)((?:clipwatching\.com|highstream.tv))/(?:embed-)?(\w+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)


### PR DESCRIPTION
- Clipwatching.com now redirects to highstream.tv
Sample link: https://highstream.tv/embed-rea1ten0jemp.html