### PR TITLE
Added Videooo.news

### DIFF
--- a/lib/resolveurl/plugins/videooo.py
+++ b/lib/resolveurl/plugins/videooo.py
@@ -1,0 +1,33 @@
+"""
+Plugin for ResolveUrl
+Copyright (C) 2021
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
+from resolveurl.plugins.lib import helpers
+
+
+class VideoooResolver(ResolveGeneric):
+    name = "videooo"
+    domains = ["videooo.news"]
+    pattern = r'(?://|\.)(videooo\.news)/(?:embed-)?([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id):
+        return helpers.get_media_url(self.get_url(host, media_id),
+                                     patterns=[r'''sources:\s*\[{file:\s*"(?P<url>[^"]+)'''])
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/embed-{media_id}.html')


### PR DESCRIPTION
Test link: https://videooo.news/embed-vv3x004ha9tf.html
OriginalURL: https://0gomovies.li/

hi @Gujal00 ,
I was trying to add Videooo.news plugin to the resolver. but I couldn't get it because it needs url where it is embedded as a referer.

is there any way to pass referer when we use `urlresolver.HostedMediaFile( url=url, title=title )`