### PR TITLE
Updated supported video extensions for debrid transfers

### DIFF
--- a/lib/resolveurl/common.py
+++ b/lib/resolveurl/common.py
@@ -38,7 +38,7 @@ has_addon = kodi.has_addon
 i18n = kodi.i18n
 
 # Supported video formats
-VIDEO_FORMATS = ['.aac', '.asf', '.avi', '.flv', '.m4a', '.m4v', '.mka', '.mkv', '.mp4', '.mpeg', '.nut', '.ogg']
+VIDEO_FORMATS = kodi.supported_video_extensions()
 
 # RAND_UA = get_ua()
 IE_USER_AGENT = 'User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko'

--- a/lib/resolveurl/lib/kodi.py
+++ b/lib/resolveurl/lib/kodi.py
@@ -75,6 +75,13 @@ def kodi_version():
     return float(xbmcaddon.Addon('xbmc.addon').getAddonInfo('version')[:4])
 
 
+def supported_video_extensions():
+    supported_video_extensions = xbmc.getSupportedMedia('video').split('|')
+    unsupported = ['.url', '.bin', '.zip', '.rar', '.001', '.disc', '.7z', '.tar.gz', '.tar.bz2',
+                   '.tar.xz', '.tgz', '.tbz2', '.gz', '.bz2', '.xz', '.tar']
+    return [i for i in supported_video_extensions if i not in unsupported]
+
+
 def open_settings():
     return addon.openSettings()
 


### PR DESCRIPTION
@Gujal00 
1. I see in the current list some audio files extensions (.aac, .ogg, .m4a, .mka). Is there a reason for this?
2. Current supported extensions list as reported by `xbmc.getSupportedMedia('video')` on Kodi 19.3 is:
```
['.m4v', '.3g2', '.3gp', '.nsv', '.tp', '.ts', '.ty', '.strm', '.pls', '.rm', '.rmvb', '.mpd', '.m3u', '.m3u8', '.ifo', '.mov', '.qt', '.divx', '.xvid', '.bivx',
'.vob', '.nrg', '.img', '.iso', '.udf', '.pva', '.wmv', '.asf', '.asx', '.ogm', '.m2v', '.avi', '.bin', '.dat', '.mpg', '.mpeg', '.mp4', '.mkv', '.mk3d',
'.avc', '.vp3', '.svq3', '.nuv', '.viv', '.dv', '.fli', '.flv', '.001', '.wpl', '.xspf', '.zip', '.vdr', '.dvr-ms', '.xsp', '.mts', '.m2t', '.m2ts', '.evo', '.ogv',
'.sdp', '.avs', '.rec', '.url', '.pxml', '.vc1', '.h264', '.rcv', '.rss', '.mpls', '.mpl', '.webm', '.bdmv', '.bdm', '.wtv', '.trp', '.f4v', '.pvr', '.disc',
'.7z', '.tar.gz', '.tar.bz2', '.tar.xz', '.zip', '.tgz', '.tbz2', '.gz', '.bz2', '.xz', '.tar']
```
I excluded
`['.url', '.bin', '.zip', '.rar', '.001', '.disc', '.7z', '.tar.gz', '.tar.bz2', '.tar.xz', '.tgz', '.tbz2', '.gz', '.bz2', '.xz', '.tar']`
Please advice/review.